### PR TITLE
fix: 배포한 vercel에서 발생하던 빌드 에러 해결

### DIFF
--- a/src/app/(withNavigation)/(home)/components/review/ReviewList.tsx
+++ b/src/app/(withNavigation)/(home)/components/review/ReviewList.tsx
@@ -9,7 +9,7 @@ const ReviewList = async () => {
   return (
     <WithTitleWrapper title="지금뜨는 리뷰" moreHref="review">
       <div className="flex flex-col gap-3">
-        {[...reviews].slice(0, 2).map(review => (
+        {reviews?.slice(0, 2).map(review => (
           <ReviewCard key={review.id} review={review} />
         ))}
       </div>

--- a/src/app/(withNavigation)/(home)/components/travelLog/TravleLogList.tsx
+++ b/src/app/(withNavigation)/(home)/components/travelLog/TravleLogList.tsx
@@ -9,7 +9,7 @@ const TravelLogList = async () => {
   return (
     <WithTitleWrapper title="사람들이 찜한 여행기" moreHref="travel-log">
       <div className="flex flex-col gap-2">
-        {[...travelLogs].slice(0, 2).map(travelLog => (
+        {travelLogs?.slice(0, 2).map(travelLog => (
           <TravelLogCard key={travelLog.id} travelLog={travelLog} />
         ))}
       </div>


### PR DESCRIPTION
### Motivation 🤔

- local에서 실행할때는 문제 없었는데 vercel에서 배포할때 항상 빌드 에러가 발생 ('TypeError: e is not iterable'..)

![스크린샷 2024-05-30 오후 9 57 18](https://github.com/J-P-plan/J-P_FE/assets/71367408/ffa4d9ac-1c0c-4797-86b4-9a28100ecf3a)

![스크린샷 2024-05-30 오후 9 57 36](https://github.com/J-P-plan/J-P_FE/assets/71367408/5480fb0a-1af3-4b5f-8bc7-adb08012a5aa)


<br />

### Key Chains 🔑

- msw에서 반환하는 api response 값인 travelLogs, reviews를 optional chaining으로 처리
  - server side에서 데이터를 호출하기 때문에 데이터가 없거나 네트워크 에러가 발생하지 않는 이상 undefined가 들어오지 않을텐데 msw에 등록한 데이터가 들어오지 않아 발생한 문제로 파악됨
  - msw가 development에서만 실행되어 반환 데이터가 undefined이고 그래서 문제가 발생한 것 인가?

<br />

### To Reviewers 🙏

- vercel 배포 테스트를 위해서 빠르게 merge하여 결과를 확인해보겠습니다. 이유는 같이 파악해봐요
- 참고로 main에 배포될때 git action으로 제 개인 private repo로 작업 내용이 전달되고, 해당 내용이 vercel에서 무료 배포되는 과정을 갖고 있습니다.
